### PR TITLE
surface errors from server

### DIFF
--- a/R/mt_dates.R
+++ b/R/mt_dates.R
@@ -72,8 +72,7 @@ mt_dates <- function(product,
   # trap errors on download, return a general error statement
   # with the most common causes.
   if (httr::http_error(json_dates)){
-    stop("Your requested timed out or the server is unreachable",
-         call. = FALSE)
+    stop(httr::content(json_dates), call. = FALSE)
   }
 
   # check the content of the json_dates, stop if not json

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -1,0 +1,27 @@
+context("test-server")
+
+test_that("error messages from server are shown to the user", {
+  skip_on_cran()
+  # temporary wrapper
+  ss <- function(lon, lat) {
+    mt_subset(product = "MOD11A2",
+              lat = lat,
+              lon = lon,
+              band = "LST_Day_1km",
+              start = "2004-01-01",
+              end = "2004-01-02",
+              progress = FALSE)
+  }
+
+  expect_silent(
+    x <- ss(-110, 40)
+  )
+  expect_error(
+    ss(40, -110),
+    "Invalid argument: Latitude must be between -90 and 90 degrees."
+  )
+  expect_error(
+    ss(400, -40),
+    "Invalid argument: Longitude must be between -180 and 180 degrees."
+  )
+})


### PR DESCRIPTION
@khufkens, I think this will provide better error messages to the user.

This PR essentially replaces the generic error message by the error returned by the server. There might be cases where it fails, but it seems to hold in the cases I've tested.

ropensci/onboarding#246