### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/mt_dates.R
+++ b/R/mt_dates.R
@@ -97,9 +97,11 @@ mt_dates <- function(
   }
 
   # try to download the data
-  json_dates <- httr::GET(url = url,
-                          query = query,
-                          httr::write_memory())
+  json_dates <- httr::RETRY(verb = "GET",
+                            url = url,
+                            query = query,
+                            httr::write_memory(),
+                            terminate_on = c(403, 404))
 
   # trap errors on download, return a general error statement
   # with the most common causes.

--- a/R/mt_subset.R
+++ b/R/mt_subset.R
@@ -201,9 +201,11 @@ mt_subset <- function(
                     "kmLeftRight" = round(km_lr))
 
       # try to download the data
-      json_chunk <- httr::GET(url = url,
-                           query = query,
-                           httr::write_memory())
+      json_chunk <- httr::RETRY(verb = "GET", 
+                                url = url,
+                                query = query,
+                                httr::write_memory(),
+                                terminate_on = c(403, 404))
 
       # trap errors on download, return a detailed
       # API error statement


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.